### PR TITLE
Social media links added correctly to the corresponding icons

### DIFF
--- a/src/LandingPage/components/Navbar.js
+++ b/src/LandingPage/components/Navbar.js
@@ -8,8 +8,8 @@ const Navbar = () => {
     { navi: "Contact", to: "/contact" },
   ];
   const socials =[
-    {  soc : "ri-facebook-circle-fill" ,src : "https://www.instagram.com" },
-    { soc : "ri-twitter-fill" ,src : "https://www.instagram.com" },
+    {  soc : "ri-facebook-circle-fill" ,src : "https://www.facebook.com" },
+    { soc : "ri-twitter-fill" ,src : "https://www.twitter.com" },
   ]
   return (
     <nav className="top-0 left-0 grid col-span-12 justify-between items-center bg-[#333] px-2 z-1000">


### PR DESCRIPTION
Facebook and Twitter icon links led to Instagram earlier. Changed  the links for the respective icons.

Closes issue #27 