### PR TITLE
fixes #40 - Inconsistency in image switching tabs 

### DIFF
--- a/src/LandingPage/stylesheets/slick-theme.css
+++ b/src/LandingPage/stylesheets/slick-theme.css
@@ -131,13 +131,19 @@
   outline: none;
   background: transparent;
 }
-.slick-dots li button:hover,
+.slick-dots li button:hover {
+  outline: none;
+  scale: 130%;
+}
 .slick-dots li button:focus {
   outline: none;
+  scale: 160%;
 }
-.slick-dots li button:hover:before,
+.slick-dots li button:hover:before {
+  opacity: 0.7;
+}
 .slick-dots li button:focus:before {
-  opacity: 1;
+  opacity: 0.4;
 }
 .slick-dots li button:before {
   font-family: "slick";


### PR DESCRIPTION
![Screenshot 2023-10-19 130539](https://github.com/arcVaishali/stellar-vision/assets/117286608/7b099d91-00f4-41fc-909a-1f192640fbf6)

The selected tab now appears bigger so its clear which is default sliding tab(black) and which is user selected(bigger brown dot).